### PR TITLE
Upgrading `fuels` to `0.96.1`

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,6 +38,6 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "fuels": "0.96.0"
+    "fuels": "0.96.1"
   }
 }

--- a/packages/sway/package.json
+++ b/packages/sway/package.json
@@ -19,6 +19,6 @@
     "elliptic": "^6.5.6"
   },
   "dependencies": {
-    "fuels": "0.96.0"
+    "fuels": "0.96.1"
   }
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -26,7 +26,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@fuel-ts/merkle": "0.94.6",
+    "@fuel-ts/merkle": "0.96.1",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.5.5",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -22,7 +22,7 @@
     "@noble/curves": "^1.5.0",
     "axios": "^1.7.2",
     "bakosafe": "workspace:*",
-    "fuels": "0.96.0",
+    "fuels": "0.96.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   axios@<0.21.1: '>=0.21.1'
   follow-redirects@<1.14.8: '>=1.14.8'
@@ -23,10 +19,10 @@ importers:
     dependencies:
       '@fuel-wallet/sdk':
         specifier: ^0.13.10
-        version: 0.13.10(dexie@4.0.8)(fuels@0.96.0)
+        version: 0.13.10(dexie@4.0.8)(fuels@0.96.1)
       '@fuel-wallet/types':
         specifier: ^0.13.10
-        version: 0.13.10(dexie@4.0.8)(fuels@0.96.0)
+        version: 0.13.10(dexie@4.0.8)(fuels@0.96.1)
       '@types/jest':
         specifier: ^29.5.4
         version: 29.5.13
@@ -56,7 +52,7 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       axios:
-        specifier: '>=1.7.4'
+        specifier: ^1.5.1
         version: 1.7.7
       uuid:
         specifier: ^9.0.1
@@ -96,8 +92,8 @@ importers:
   packages/sway:
     dependencies:
       fuels:
-        specifier: 0.96.0
-        version: 0.96.0
+        specifier: 0.96.1
+        version: 0.96.1
     devDependencies:
       '@types/node':
         specifier: ^16.18.104
@@ -106,7 +102,7 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       elliptic:
-        specifier: '>=6.5.7'
+        specifier: ^6.5.6
         version: 6.5.7
 
   packages/tests:
@@ -115,21 +111,21 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       axios:
-        specifier: '>=1.7.4'
+        specifier: ^1.7.2
         version: 1.7.7
       bakosafe:
         specifier: workspace:*
         version: link:../sdk
       fuels:
-        specifier: 0.96.0
-        version: 0.96.0
+        specifier: 0.96.1
+        version: 0.96.1
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
     devDependencies:
       '@fuel-ts/merkle':
-        specifier: 0.94.6
-        version: 0.94.6
+        specifier: 0.96.1
+        version: 0.96.1
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
@@ -910,6 +906,20 @@ packages:
       '@fuel-ts/math': 0.96.0
       '@fuel-ts/utils': 0.96.0
       type-fest: 4.26.1
+    dev: true
+
+  /@fuel-ts/abi-coder@0.96.1:
+    resolution: {integrity: sha512-czJxFPirhSO6ayshu9Cr5AmED/IprQ8h1igwlcSHFr5jR+l46bLdlsXsWiUwe7vyvZCpOnxkN/XZYkmQyNxKNg==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      type-fest: 4.26.1
+    dev: false
 
   /@fuel-ts/abi-typegen@0.96.0:
     resolution: {integrity: sha512-EFWUMa+aKMvgZSPc7we0exrfp9qKbw6E+CSlGUYy1JZBZwaaBHsRrQ2EGL9d9q6doWD4VamV+y9Fgj6MYeuGkQ==}
@@ -926,6 +936,24 @@ packages:
       mkdirp: 3.0.1
       ramda: 0.30.1
       rimraf: 5.0.10
+    dev: true
+
+  /@fuel-ts/abi-typegen@0.96.1:
+    resolution: {integrity: sha512-vRJnAQ9sxkKuUQ2fkxntPm/679grxgwSf54O7vgDeXuXqQx/4XeylpExjH0/nZzEM5al+muw4rg9WwmKulkcZA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    hasBin: true
+    dependencies:
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
+      commander: 12.1.0
+      glob: 10.4.5
+      handlebars: 4.7.8
+      mkdirp: 3.0.1
+      ramda: 0.30.1
+      rimraf: 5.0.10
+    dev: false
 
   /@fuel-ts/account@0.96.0:
     resolution: {integrity: sha512-zpcpf4NR9vMcHoAfpXgp7SAqHf8hmRgtWGuLReqQnqcJz2g14pF7aIue+bF6kLuBf3o0YrINMPkuFlzLBgxBFQ==}
@@ -951,6 +979,33 @@ packages:
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
+    dev: true
+
+  /@fuel-ts/account@0.96.1:
+    resolution: {integrity: sha512-i9InTebg3/buKXNJZpKBhxGMBC3MKpk905Uiv2CvTmldyPVgnZV/jY/b63jlfdEWyP5yVkr5/tzo7QaPKpfnMA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
+      '@fuels/vm-asm': 0.58.0
+      '@noble/curves': 1.6.0
+      events: 3.3.0
+      graphql: 16.9.0
+      graphql-request: 5.0.0(graphql@16.9.0)
+      graphql-tag: 2.12.6(graphql@16.9.0)
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@fuel-ts/address@0.96.0:
     resolution: {integrity: sha512-IU7bVyqjQnHJmnqApbEkAGwvEwImc/QoCCciw3KhkiV4OP/LneOZvOtLKMAWkorBcNeAnw6U1sIRIY8jYHGIYw==}
@@ -962,6 +1017,19 @@ packages:
       '@fuel-ts/utils': 0.96.0
       '@noble/hashes': 1.5.0
       bech32: 2.0.0
+    dev: true
+
+  /@fuel-ts/address@0.96.1:
+    resolution: {integrity: sha512-PCuC8oojoWLhh0+boitaP90/Z3iSfEXZR8v1JCEfoLZIkvCq6EGKtiY0KvcNkPozHOHmmT34w/1CS6qHOoCBNA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@noble/hashes': 1.5.0
+      bech32: 2.0.0
+    dev: false
 
   /@fuel-ts/contract@0.96.0:
     resolution: {integrity: sha512-HlMtR+MVUGgQby6NU5/ezO5Li8zfjYrezvaAlVoJtm68r2QDZkeQId4JtD2za7Z1Im6A3eAm4nk9gUIHo6eluw==}
@@ -983,17 +1051,29 @@ packages:
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
+    dev: true
 
-  /@fuel-ts/crypto@0.94.6:
-    resolution: {integrity: sha512-QagAhB7O9gV6fDiEsJnvaURNA8OklE9uKuaCcrxNVpzzxgapreZU6b99oAV9zctiojNn3JcF3UYqVCE9SIgZEw==}
+  /@fuel-ts/contract@0.96.1:
+    resolution: {integrity: sha512-shwNMHFZ7vr5QJsfVQ6aLd1ms88f3ZagrsNLqNz1Txhz/5KVgYyJaxfp7tUc4WZFpR67+W1zeIqx8ZNHVhck3g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
-      '@fuel-ts/errors': 0.94.6
-      '@fuel-ts/interfaces': 0.94.6
-      '@fuel-ts/math': 0.94.6
-      '@fuel-ts/utils': 0.94.6
-      '@noble/hashes': 1.5.0
-    dev: true
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
+      '@fuels/vm-asm': 0.58.0
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@fuel-ts/crypto@0.96.0:
     resolution: {integrity: sha512-Vl76bhtQj3HliXwm3ihgh2zsIK1jsY/eX8XdgCoc8MmQxureNLdbuxv/PKuqRNcUCWkMdhKj11fitwzGVs5VRA==}
@@ -1004,29 +1084,30 @@ packages:
       '@fuel-ts/math': 0.96.0
       '@fuel-ts/utils': 0.96.0
       '@noble/hashes': 1.5.0
+    dev: true
 
-  /@fuel-ts/errors@0.94.6:
-    resolution: {integrity: sha512-qMYI9acCZm1ISDPgTLtW21UwypL6g+X8OGxOgmeQajM8SvT3Zj6cot3q6YM+ZCmo9ZB3IWOOtam7hXTK7MKawQ==}
+  /@fuel-ts/crypto@0.96.1:
+    resolution: {integrity: sha512-OrAZPZtm8HQouzip621/ci47PeTS06QegGdz7MeN6wK4yeCbJmlRQ1WE9S3iclb3p+VLF0RtbecEbHQfsNgsnA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
-      '@fuel-ts/versions': 0.94.6
-    dev: true
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@noble/hashes': 1.5.0
 
   /@fuel-ts/errors@0.96.0:
     resolution: {integrity: sha512-PXR+gaa8UNIYJuzs/doDLwPNyqU1ctp691XVhWS+usRRqiLPgcS2+0rUKF2lr5kdfH7RWEdzU/muymVOJBpOWA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
       '@fuel-ts/versions': 0.96.0
+    dev: true
 
-  /@fuel-ts/hasher@0.94.6:
-    resolution: {integrity: sha512-hg2judiu3Ci1wCbi5DMIMeWcf3jOZK1dmNiPEJu19BV32uw44QmlnV89uXIxDwLOSxlmiI+dxJOi4vF+domfeg==}
+  /@fuel-ts/errors@0.96.1:
+    resolution: {integrity: sha512-Xtso5v4a3UUvnMaOSDhMRlkb9LxLyCyC/1/RY7fZZ035ttscy6dNMuiD/iSptJ5pHklJ5R4rCPdOL5EKpgOaMA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
-      '@fuel-ts/crypto': 0.94.6
-      '@fuel-ts/interfaces': 0.94.6
-      '@fuel-ts/utils': 0.94.6
-      '@noble/hashes': 1.5.0
-    dev: true
+      '@fuel-ts/versions': 0.96.1
 
   /@fuel-ts/hasher@0.96.0:
     resolution: {integrity: sha512-Zo53yBx1WHbm0j6h5F1j/drDv1yfxW3NLovJFIL4PBRObrU/DlWtiBufkAMWZa1q3IIX1zji8oTIf/7zPIDJkw==}
@@ -1036,24 +1117,25 @@ packages:
       '@fuel-ts/interfaces': 0.96.0
       '@fuel-ts/utils': 0.96.0
       '@noble/hashes': 1.5.0
-
-  /@fuel-ts/interfaces@0.94.6:
-    resolution: {integrity: sha512-wR+ZGUT1Jjj7LifmvHfBIAIZRwjXUYddwT6SDptBglDQkJGlMwEHv8xh76FU0W764NwWGRqoX2TeZKIdu4fD/w==}
-    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dev: true
+
+  /@fuel-ts/hasher@0.96.1:
+    resolution: {integrity: sha512-7z4cah+5TOcCBA2Wgvje1L7wVTahiFLb9IUpRXRMVGXwaqsbV/wUNcyuc1mhPh/JKLgcOe+OqsrpcYD2dg2rpg==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@noble/hashes': 1.5.0
 
   /@fuel-ts/interfaces@0.96.0:
     resolution: {integrity: sha512-/9hhmnokFvELhsufPMNuSVc+q2FueGDEPQ2AMOrgbnefBvB6y8ON5t7yjapQo/s8BVxUWIdvlnCS2Cn9OUJ/iQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
-
-  /@fuel-ts/math@0.94.6:
-    resolution: {integrity: sha512-VIgVv3Qdy4wjuR7ehlvOz+fo6WZPuoWLnACBu4xeMEwUrSZRJrDGBSG3FKBcJOBwIX9olbWseCNTccRWcLinMQ==}
-    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
-    dependencies:
-      '@fuel-ts/errors': 0.94.6
-      '@types/bn.js': 5.1.5
-      bn.js: 5.2.1
     dev: true
+
+  /@fuel-ts/interfaces@0.96.1:
+    resolution: {integrity: sha512-mZ3sDHJml5AtLRSmGWo5rbU9//3oKDhAeiFealajcPaVztAAnaKnA5a19dd4ITbjZb2q3e2lQ7zX8iAXgHUwYA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
   /@fuel-ts/math@0.96.0:
     resolution: {integrity: sha512-DZW4kEAR5BbTuWAonakaigCpW9nHuVuLXTwqMUyYbIRy/mYzAA2ui713F/Yn67GBCVRez3bOXzUc7TH2QUNKRg==}
@@ -1062,14 +1144,15 @@ packages:
       '@fuel-ts/errors': 0.96.0
       '@types/bn.js': 5.1.6
       bn.js: 5.2.1
+    dev: true
 
-  /@fuel-ts/merkle@0.94.6:
-    resolution: {integrity: sha512-Fh+WYEo+XbuErueWhP0Y9telf4LJPQNqIS46TqPL6r95cfLVgawATTc8LjbaJPaEjxl2ET7WGlAVWIK1kdeIjQ==}
+  /@fuel-ts/math@0.96.1:
+    resolution: {integrity: sha512-AZUChguQmE1ILYbcc6SOTjFJIUkGzD3Z6yHgvO4tszn2QS/jVTSAZKVx653J5u9m/Xn/WthwR35l1GbwXMwB4g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
-      '@fuel-ts/hasher': 0.94.6
-      '@fuel-ts/math': 0.94.6
-    dev: true
+      '@fuel-ts/errors': 0.96.1
+      '@types/bn.js': 5.1.6
+      bn.js: 5.2.1
 
   /@fuel-ts/merkle@0.96.0:
     resolution: {integrity: sha512-ZIWq8qLx2BHussNp1AyTx5MZY7ersgPrWrVq5LULgUZaE4z8nY9DNSyLblwTlET3cs+u4umNRkjrm0AEkvyGpA==}
@@ -1077,6 +1160,14 @@ packages:
     dependencies:
       '@fuel-ts/hasher': 0.96.0
       '@fuel-ts/math': 0.96.0
+    dev: true
+
+  /@fuel-ts/merkle@0.96.1:
+    resolution: {integrity: sha512-7cLbxYG5berKSK+wPKrkbB9dZ6akOm7C1Ij4iwYXOxQWlmXY62mjSY5Tl1PPyDBSdRqBtqxW0xYUGIzZl2A/3g==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/math': 0.96.1
 
   /@fuel-ts/program@0.96.0:
     resolution: {integrity: sha512-OXtKOm0zsDl7U9NrBFr8Q92piH87OAZMDBpvCJesv8IGXqLR6+O0MhNa8RDls5gIf5pgGyd1LyWzfTHOdiRv9A==}
@@ -1094,6 +1185,25 @@ packages:
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
+    dev: true
+
+  /@fuel-ts/program@0.96.1:
+    resolution: {integrity: sha512-tA2YvcIdlDQLKeOOfoTyfI3LRQZiqsHi5rFaGbOsjEQvyNQBdXa92vMMFW0dFNWXqOPLjTmYNWqp0xsMuikbsA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuels/vm-asm': 0.58.0
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@fuel-ts/script@0.96.0:
     resolution: {integrity: sha512-3X3G+vMLjWQfIP2TY+riHYJ5jJV6/ii7yRfkHyKJ0ntnY59kLVfsA97BkXVAe1GFdV0Hw8xXRPhDlCPIuABTYQ==}
@@ -1110,6 +1220,24 @@ packages:
       '@fuel-ts/utils': 0.96.0
     transitivePeerDependencies:
       - encoding
+    dev: true
+
+  /@fuel-ts/script@0.96.1:
+    resolution: {integrity: sha512-N/N3I3xjDI1+9XcCrYTWapF0iBbdvtBxUUUZxn5S5GuIXuTCK6UfQLrRciuCHK5QiHVwFmQjlki+ozJfI+4UbQ==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@fuel-ts/transactions@0.96.0:
     resolution: {integrity: sha512-hLRgfO+DlpJHWBDcuCW9vh8yh8kQh/nuhtK/VlfknfITFR+gCcnJCqtEtP95qOwElqkiRBm9+VQJBK3qATWPVA==}
@@ -1122,17 +1250,20 @@ packages:
       '@fuel-ts/interfaces': 0.96.0
       '@fuel-ts/math': 0.96.0
       '@fuel-ts/utils': 0.96.0
+    dev: true
 
-  /@fuel-ts/utils@0.94.6:
-    resolution: {integrity: sha512-v/eHwuVZCeiSF4ywZ7mmrMMzOBWU9mcsG5Iu4F598UDWqL6CLSuf3DbATGAE8Dt23JNPzqtSSn7TT+LVdfT8tQ==}
+  /@fuel-ts/transactions@0.96.1:
+    resolution: {integrity: sha512-yPQBzMeFIzNBLUZigaf4q0hETO8AH8Evt6ZvpWrYhjYz2WfEpfNDpuhIHRwsMfJRbxz2vhQ51AzkRqpH0b2GMQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     dependencies:
-      '@fuel-ts/errors': 0.94.6
-      '@fuel-ts/interfaces': 0.94.6
-      '@fuel-ts/math': 0.94.6
-      '@fuel-ts/versions': 0.94.6
-      fflate: 0.8.2
-    dev: true
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+    dev: false
 
   /@fuel-ts/utils@0.96.0:
     resolution: {integrity: sha512-ME5xLtXocxszic9kIfT51oYAeJdeaCSlvBhAyFzAAyLlbkcL/pPU1d35Dm0ghyxMTEAOO/11CXMBPESIdM54aw==}
@@ -1143,15 +1274,17 @@ packages:
       '@fuel-ts/math': 0.96.0
       '@fuel-ts/versions': 0.96.0
       fflate: 0.8.2
-
-  /@fuel-ts/versions@0.94.6:
-    resolution: {integrity: sha512-R/KcgrGe64IhFQkNDQmUnILrMKtKXhaxB+WoDtYho25a79wxq1M+D9Be7kcg+ku2hPjfvk89OaIzD1cZhUx7xg==}
-    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      cli-table: 0.3.11
     dev: true
+
+  /@fuel-ts/utils@0.96.1:
+    resolution: {integrity: sha512-XXZNEUPf7qtKpVO3ak2CSroBYEKh1Gne1zlmVSNUoVPqQvglcu0I2pu/QmVnZBN4m3yVSyHUoWR2Kbo8/Dh7sA==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    dependencies:
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/versions': 0.96.1
+      fflate: 0.8.2
 
   /@fuel-ts/versions@0.96.0:
     resolution: {integrity: sha512-uffrtpkCguzsVkCLW7tuZG1BwNu69LCjy8sO831VcpZsDRzIy3qO/om9X17W2HTJXxSS+25ok4t7fThIF+w6Gg==}
@@ -1160,16 +1293,25 @@ packages:
     dependencies:
       chalk: 4.1.2
       cli-table: 0.3.11
+    dev: true
 
-  /@fuel-wallet/sdk@0.13.10(dexie@4.0.8)(fuels@0.96.0):
+  /@fuel-ts/versions@0.96.1:
+    resolution: {integrity: sha512-C//ZT7U68Gksz9PzUJVzdzUARK7mfXf3MsF5ZqZaMegkE2tCy+twjy8PBdeVserY0uX6mEHRJyZJwcspk34ixg==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      cli-table: 0.3.11
+
+  /@fuel-wallet/sdk@0.13.10(dexie@4.0.8)(fuels@0.96.1):
     resolution: {integrity: sha512-KEef3lE5Z2fWC2noWNsLxQgpJdeX0oqKOFSeLA7lPQl+HlN9KKdeZ401bDeFbehTmx0OSb7JWF3d79NMK6OtdQ==}
     peerDependencies:
       fuels: '>=0.67.0'
     dependencies:
-      '@fuel-wallet/types': 0.13.10(dexie@4.0.8)(fuels@0.96.0)
+      '@fuel-wallet/types': 0.13.10(dexie@4.0.8)(fuels@0.96.1)
       dexie-observable: 4.0.1-beta.13(dexie@4.0.8)
       events: 3.3.0
-      fuels: 0.96.0
+      fuels: 0.96.1
       json-rpc-2.0: 1.7.0
       uuid: 9.0.1
       xstate: 4.38.3
@@ -1177,14 +1319,14 @@ packages:
       - dexie
     dev: false
 
-  /@fuel-wallet/types@0.13.10(dexie@4.0.8)(fuels@0.96.0):
+  /@fuel-wallet/types@0.13.10(dexie@4.0.8)(fuels@0.96.1):
     resolution: {integrity: sha512-b0OTv2yoBqUUERPgw5NleX8ajJxzLXEGLoxI26gpChXAsd3JpMkfR2cH2jr7rglytA++NlPe3X8VW+UtoBK7DA==}
     peerDependencies:
       fuels: '>=0.67.0'
     dependencies:
       '@types/chrome': 0.0.246
       dexie-observable: 4.0.1-beta.13(dexie@4.0.8)
-      fuels: 0.96.0
+      fuels: 0.96.1
       json-rpc-2.0: 1.7.0
     transitivePeerDependencies:
       - dexie
@@ -2527,6 +2669,46 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
+
+  /fuels@0.96.1:
+    resolution: {integrity: sha512-BquRIJ0qHNKwhqBTNa6X4aghqhCj1Qz0jM+P0bziXAEk7gVJJZWRz10jCcAgZVeEb4AMdZLDsnNzKJ51GH8IvQ==}
+    engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
+    hasBin: true
+    dependencies:
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/abi-typegen': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/contract': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/script': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
+      bundle-require: 5.0.0(esbuild@0.24.0)
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      commander: 12.1.0
+      esbuild: 0.24.0
+      glob: 10.4.5
+      handlebars: 4.7.8
+      joycon: 3.1.1
+      lodash.camelcase: 4.3.0
+      portfinder: 1.0.32
+      toml: 3.0.0
+      uglify-js: 3.19.3
+      yup: 1.4.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -4470,3 +4652,7 @@ packages:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary
Upgrade `fuels` versions to the latest

```
LICENSE:
The Fuel Support team submits this PR to help you use the fuel SDKs. It is provided "as is" 
and without warranty for any purpose. We are not participants in the project at hand. 
All the rights of this code are reserved to the authors of this repository.
```