### PR TITLE
fix(provider): use server url of provider options

### DIFF
--- a/.changeset/curvy-tomatoes-film.md
+++ b/.changeset/curvy-tomatoes-film.md
@@ -1,0 +1,5 @@
+---
+'bakosafe': patch
+---
+
+fix(provider): use server url of provider options

--- a/.changeset/fast-eagles-develop.md
+++ b/.changeset/fast-eagles-develop.md
@@ -1,0 +1,5 @@
+---
+'bakosafe': patch
+---
+
+chore(vault): add description property

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bakosafe",
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "author": "Bako Labs",
   "description": "A signature validation package built based on sway in the fuel network",
   "main": "dist/index.js",

--- a/packages/sdk/src/modules/provider/BakoProvider.ts
+++ b/packages/sdk/src/modules/provider/BakoProvider.ts
@@ -85,11 +85,12 @@ export class BakoProvider extends Provider {
       const { apiToken, ...rest } = options;
       const providerFuel = await Provider.create(url);
       const cliAuth = await Service.cliAuth({
-        token: options.apiToken,
         network: {
           url: providerFuel.url,
           chainId: providerFuel.getChainId(),
         },
+        token: options.apiToken,
+        serverApi: options.serverApi,
       });
       const provider = new BakoProvider(url, {
         ...rest,

--- a/packages/sdk/src/modules/provider/BakoProvider.ts
+++ b/packages/sdk/src/modules/provider/BakoProvider.ts
@@ -135,6 +135,7 @@ export class BakoProvider extends Provider {
   async savePredicate(
     vault: Vault & {
       name?: string;
+      description?: string;
     },
   ) {
     const payload: IPredicatePayload = {
@@ -143,6 +144,7 @@ export class BakoProvider extends Provider {
       configurable: JSON.stringify(vault.configurable),
       provider: this.url,
       version: vault.predicateVersion,
+      description: vault.description,
     };
 
     const predicate = await this.service.createPredicate(payload);

--- a/packages/sdk/src/modules/provider/types.ts
+++ b/packages/sdk/src/modules/provider/types.ts
@@ -9,6 +9,7 @@ export type BakoProviderOptions = ProviderOptions & {
 
 export type BakoProviderAPITokenOptions = ProviderOptions & {
   apiToken: string;
+  serverApi?: string;
 };
 
 export type BakoProviderAuthOptions = BakoProviderOptions & {

--- a/packages/sdk/src/modules/service/service.ts
+++ b/packages/sdk/src/modules/service/service.ts
@@ -15,7 +15,7 @@ import {
   TransactionBakoResponse,
   UserAuthResponse,
   CLIAuthPayload,
-  CLIAuth
+  CLIAuth,
 } from './types';
 
 // keep here to sync with the other files
@@ -190,12 +190,15 @@ export class Service {
   }
 
   /**
-   * Authenticate with a API Token
+   * Authenticate with an API Token
    * @param {CLIAuthPayload} params - The CLI authentication payload.
    * @returns {Promise<CLIAuth>}    - The response containing the CLI authentication details.
    */
   static async cliAuth(params: CLIAuthPayload): Promise<CLIAuth> {
-    const { data } = await api.post<CLIAuth>('/cli/auth', params);
+    const { serverApi = defaultConfig.serverUrl, ...payload } = params;
+
+    const api = axios.create({ baseURL: serverApi });
+    const { data } = await api.post<CLIAuth>('/cli/auth', payload);
 
     return data;
   }

--- a/packages/sdk/src/modules/service/types.ts
+++ b/packages/sdk/src/modules/service/types.ts
@@ -214,6 +214,7 @@ export type CLIAuthPayload = {
     url: string;
     chainId: number;
   };
+  serverApi?: string;
 };
 
 export type CLIAuth = {

--- a/packages/sdk/src/modules/vault/Vault.ts
+++ b/packages/sdk/src/modules/vault/Vault.ts
@@ -289,6 +289,7 @@ export class Vault extends Predicate<[]> {
   async save(
     params: {
       name?: string;
+      description?: string;
     } = {},
   ): Promise<PredicateResponse> {
     if (this.provider instanceof BakoProvider) {


### PR DESCRIPTION
Closes: https://github.com/Bako-Labs/bako-safe/issues/23

## Summary
- [x] Use the server URL defined by the BakoProvider configuration.
- [x] Enable to set description on vault.

## Description
<!-- Briefly describe your changes -->

## Checklist
- [x] Tests
- [ ] Documentation
- [x] Changelog
- [ ] Dependencies
- [ ] Security
<!-- Mark with an 'x' the items that apply to this PR -->
