### PR TITLE
Ensure the transaction has funds to pay the fee and…

### DIFF
--- a/.changeset/few-lizards-call.md
+++ b/.changeset/few-lizards-call.md
@@ -1,0 +1,5 @@
+---
+'bakosafe': patch
+---
+
+fix(transaction): ensure the transaction has funds to pay the fee and outputs

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bakosafe",
-  "version": "0.1.8",
+  "version": "0.1.9-beta.2",
   "author": "Bako Labs",
   "description": "A signature validation package built based on sway in the fuel network",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bakosafe",
-  "version": "0.1.9-beta.2",
+  "version": "0.1.9-beta.3",
   "author": "Bako Labs",
   "description": "A signature validation package built based on sway in the fuel network",
   "main": "dist/index.js",

--- a/packages/sdk/src/modules/vault/Vault.ts
+++ b/packages/sdk/src/modules/vault/Vault.ts
@@ -251,7 +251,10 @@ export class Vault extends Predicate<[]> {
       if (transactionRequest.maxFee.lt(transactionCost.maxFee)) {
         transactionRequest.maxFee = transactionCost.maxFee;
       }
-      if ('gasLimit' in transactionRequest) {
+      if (
+        'gasLimit' in transactionRequest &&
+        transactionRequest.gasLimit.lt(transactionCost.gasUsed)
+      ) {
         transactionRequest.gasLimit = transactionCost.gasUsed;
       }
       transactionRequest = await this.fund(transactionRequest, transactionCost);

--- a/packages/sdk/src/modules/vault/Vault.ts
+++ b/packages/sdk/src/modules/vault/Vault.ts
@@ -251,6 +251,9 @@ export class Vault extends Predicate<[]> {
       if (transactionRequest.maxFee.lt(transactionCost.maxFee)) {
         transactionRequest.maxFee = transactionCost.maxFee;
       }
+      if ('gasLimit' in transactionRequest) {
+        transactionRequest.gasLimit = transactionCost.gasUsed;
+      }
       transactionRequest = await this.fund(transactionRequest, transactionCost);
 
       let totalGasUsed = bn(0);


### PR DESCRIPTION
## Summary
- [x] Refund transaction when not fund's to pay the fee + outputs

## Description
When a vault contains `0.003 ETH` (three UTXOs of 0.001 ETH) and the initial maxFee is `0.00001 ETH`, the following happens when sending a transaction of `0.0009 ETH`:
- A UTXO of `0.001 ETH` is included because, in the initial calculation, the UTXO value plus the initial maxFee is sufficient to cover the transaction.
- Then, the actual maxFee is recalculated (let's assume it is 0.0002 ETH).
- Since the maxFee has been updated, the total transaction amount is now `0.0009 ETH + 0.0002 ETH = 0.0011 ETH`.
- The inserted UTXO was 0.001 ETH, but the total transaction amount is `0.0011 ETH`. This results in the `InsufficientFeeAmount` error because the UTXO value is not enough to cover the transaction.
