### PR TITLE
FEAT: add prefix to social address

### DIFF
--- a/.changeset/flat-forks-protect.md
+++ b/.changeset/flat-forks-protect.md
@@ -1,0 +1,5 @@
+---
+'bakosafe': patch
+---
+
+Address can be formatted with the prefix `social`

--- a/packages/sdk/src/modules/address/Address.ts
+++ b/packages/sdk/src/modules/address/Address.ts
@@ -16,21 +16,25 @@ export class AddressUtils {
     return value.startsWith(Bech32Prefix.PASSKEY);
   }
 
+  static isSocial(value: string): boolean {
+    return value.startsWith(Bech32Prefix.SOCIAL);
+  }
+
   /**
-   * @deprecated Use toPasskey instead
+   * Converts a hex address to Bech32 prefix format
+   * @param address - The hex address to convert
+   * @param prefix - The Bech32 prefix to use
+   * @returns The Bech32 address with the specified prefix
    */
-  static toBech32 = (address: string) =>
-    <Bech32>(
-      bech32m.encode(
-        Bech32Prefix.PASSKEY,
-        bech32m.toWords(arrayify(hexlify(address))),
-      )
-    );
+  static toBech32 = (address: string, prefix: Bech32Prefix) =>
+    <Bech32>bech32m.encode(prefix, bech32m.toWords(arrayify(hexlify(address))));
 
   /**
    * Converts a hex address to Bech32 passkey format
    * @param address - The hex address to convert
    * @returns The Bech32 passkey address
+   *
+   * @deprecated Use toBech32 instead
    */
   static toPasskey = (address: string) =>
     <Bech32>(

--- a/packages/sdk/src/modules/address/README.md
+++ b/packages/sdk/src/modules/address/README.md
@@ -32,13 +32,17 @@ Converts an array of hex addresses to string representation, filtering out ZeroB
 
 Checks if an address is a passkey address by verifying if it starts with the passkey prefix.
 
-### toBech32(address: string): Bech32
+### isSocial(value: string): boolean
 
-**@deprecated** Use `toPasskey` instead.
+Checks if an address is a social address by verifying if it starts with the social prefix.
 
-Converts a hex address to Bech32 passkey format.
+### toBech32(address: string, prefix: Bech32Prefix): Bech32
+
+Converts a hex address to Bech32 prefix format.
 
 ### toPasskey(address: string): Bech32
+
+**@deprecated** Use `toBech32` instead.
 
 Converts a hex address to Bech32 passkey format.
 

--- a/packages/sdk/src/modules/address/types.ts
+++ b/packages/sdk/src/modules/address/types.ts
@@ -1,6 +1,6 @@
 export enum Bech32Prefix {
   PASSKEY = 'passkey',
+  SOCIAL = 'social',
 }
 
 export type Bech32 = `${Bech32Prefix}.${string}`;
-

--- a/packages/tests/src/configurable.test.ts
+++ b/packages/tests/src/configurable.test.ts
@@ -1,4 +1,4 @@
-import { Vault, ConfigVaultType, AddressUtils } from 'bakosafe';
+import { Vault, ConfigVaultType, AddressUtils, Bech32Prefix } from 'bakosafe';
 import { Address, Provider, ZeroBytes32 } from 'fuels';
 import { launchTestNode } from 'fuels/test-utils';
 import { accounts } from './mocks';
@@ -137,7 +137,10 @@ describe('[Configurable Functions]', () => {
     it('should create vault for compatible version webauthn_wallet:evm_connector_version', () => {
       const webauthn_wallet = WebAuthn.createCredentials();
       const connectorConfig = {
-        SIGNER: AddressUtils.toPasskey(webauthn_wallet.address),
+        SIGNER: AddressUtils.toBech32(
+          webauthn_wallet.address,
+          Bech32Prefix.PASSKEY,
+        ),
       };
 
       expect(() => {


### PR DESCRIPTION
## Summary
- Address can be formatted with the prefix `social`

## Description
- Adds new address prefix: `social`
- Adds prefix parameter to `toBech32` method
- `toBech32` method is no longer deprecated
- `toPasskey` method is deprecated
- Adds `isSocial` method to identify whether an address has the prefix `social`
- Updates test that used deprecated function

## Checklist
- [x] Tests
- [x] Documentation
- [x] Changelog
- [x] Dependencies
- [ ] Security
<!-- Mark with an 'x' the items that apply to this PR -->
