### PR TITLE
FIX: changes default bako api url to prod

### DIFF
--- a/.changeset/flat-forks-unite.md
+++ b/.changeset/flat-forks-unite.md
@@ -1,0 +1,5 @@
+---
+'bakosafe': patch
+---
+
+changes default bako server api url to prod

--- a/packages/sdk/src/constantes.ts
+++ b/packages/sdk/src/constantes.ts
@@ -1,3 +1,1 @@
-// export const BAKO_SERVER_API = 'https://api.bako.global/';
-// export const BAKO_SERVER_API = 'http://localhost:3333/';
-export const BAKO_SERVER_API = 'https://stg-api.bako.global/';
+export const BAKO_SERVER_API = 'https://api.bako.global/';


### PR DESCRIPTION
## Summary
- Fixes the error when attempting to create a transaction with an API token without providing the `serverApi` param

## Description
- Changes default bako api url to prod

## Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
- [ ] Dependencies
- [ ] Security
<!-- Mark with an 'x' the items that apply to this PR -->
