### PR TITLE
fix: upgrade fuels to 0.103.0 (fuel-core 0.47.1)

### DIFF
--- a/.changeset/fuels-upgrade.md
+++ b/.changeset/fuels-upgrade.md
@@ -1,0 +1,5 @@
+---
+"bakosafe": patch
+---
+
+fix: upgrade fuels to 0.103.0 for fuel-core 0.47.1 compatibility

--- a/fuel-toolchain.toml
+++ b/fuel-toolchain.toml
@@ -2,5 +2,5 @@
 channel = "testnet"
 
 [components]
-fuel-core = "0.43.1"
+fuel-core = "0.47.1"
 forc = "0.68.1"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bakosafe",
-  "version": "0.6.1",
+  "version": "0.6.2-rc.0",
   "author": "Bako Labs",
   "description": "A signature validation package built based on sway in the fuel network",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "@types/uuid": "^9.0.6",
     "bech32": "^2.0.0",
     "dotenv": "^16.4.1",
-    "fuels": "0.101.3",
+    "fuels": "0.103.0",
     "patch-package": "8.0.0",
     "prettier": "3.0.3",
     "tsup": "^7.2.0",
@@ -45,6 +45,6 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "fuels": "^0.101.0"
+    "fuels": "^0.102.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^16.4.1
         version: 16.6.1
       fuels:
-        specifier: 0.101.3
-        version: 0.101.3(vitest@3.0.9)
+        specifier: 0.103.0
+        version: 0.103.0(vitest@3.0.9)
       patch-package:
         specifier: 8.0.0
         version: 8.0.0
@@ -1367,6 +1367,21 @@ packages:
       type-fest: 4.34.1
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/abi-coder@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-tErLljHqz8Tnpndijd3XiGSbsBanFCeq2Bbl5DBjbVrZ737m5BqsYVYgBjSDkRmrRxz/uFFmXl1qLEU3MWNtPQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      type-fest: 4.34.1
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/abi-typegen@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-WWXESg9SaBOLBXYsTeW5We3LA2aHzRhCzUAp5UDqaCChztzAyyj4aXd68zpUiJ5UlH3C6bxgv2zHMhWMo+rriA==}
@@ -1384,6 +1399,25 @@ packages:
       rimraf: 5.0.10
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/abi-typegen@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-XO9zai8MomXjCHnoa7K/gfO/Nco6Atmu8ptPJ1rHkhbftP75jXp5owflVFe+e+zvIXPA/UsZkM/uxJN0fB2njg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    hasBin: true
+    dependencies:
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/versions': 0.103.0
+      commander: 13.1.0
+      glob: 10.4.5
+      handlebars: 4.7.8
+      mkdirp: 3.0.1
+      ramda: 0.30.1
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/account@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-ubDVW4NSRdTEyaAFUnL75+ysjLcb+/5M3Rtk5hFDawhcrA9rSB0UDel5lOavERuJlKPtu4jngcv8nTiXdu4mGw==}
@@ -1409,6 +1443,33 @@ packages:
     transitivePeerDependencies:
       - encoding
       - vitest
+    dev: false
+
+  /@fuel-ts/account@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-FI4iPK6yYtdU8d+pwknyVtOLAsxP0raybH3gPAWhYR7Bp4C4iA6dXnGXQcznBEW52Ez++5LjqvejJjZkIOzohw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/merkle': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/versions': 0.103.0
+      '@fuels/vm-asm': 0.62.0
+      '@noble/curves': 1.8.1
+      events: 3.3.0
+      graphql: 16.10.0
+      graphql-request: 6.1.0(graphql@16.10.0)
+      graphql-tag: 2.12.6(graphql@16.10.0)
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+      - vitest
+    dev: true
 
   /@fuel-ts/address@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-GbolfGNSSx8hEHPxI4ayD3MAhnHMCg3mqCFncTXXFaL2uMK82aSvab8s0QLNxcIPZmS9T5rOCMY0sqwm5ahh7w==}
@@ -1420,6 +1481,19 @@ packages:
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/address@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-Yb/mpU+4D4a6OdTLAvVeEFncNSLtW4NjToxdceDIv/y45TDFdubwcmMw+7gA/fDcn+6p88mojrcCEcRrnDg2qQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@noble/hashes': 1.7.1
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/contract@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-uMpELAr/jkyyNIUCuCrTKbhT1oH/smUEVKL7D+4HvJ2nqn7xO4XdaNFGf6/5qylElDP8xn4Xtte8sb+d9UeZTA==}
@@ -1440,6 +1514,28 @@ packages:
     transitivePeerDependencies:
       - encoding
       - vitest
+    dev: false
+
+  /@fuel-ts/contract@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-pdYxN7beDNn+JYRmQ1/1TYEK0QcWB4WvQsmAWlESE2WzmlMVDqoa4U1U5rsh5uZde1/Jb3TikXJeSWpyRa4J5Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/account': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/merkle': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/program': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@fuels/vm-asm': 0.62.0
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+      - vitest
+    dev: true
 
   /@fuel-ts/crypto@0.101.1(vitest@3.0.9):
     resolution: {integrity: sha512-Dy6Q1NbdGojyT0q3mrZu72hSTlXfNprKA6A6vJHKkwRcwFphnrZHAubVfjzus4ZeQf9fdcqZrfWLUG76/F6r9g==}
@@ -1461,6 +1557,18 @@ packages:
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/crypto@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-8DWeYl1TkXY7Ga/2X1zI4Jv6Ua7mFHRgArwaSV0ckhk+Fu+KK4K9diUAge10TRUe11byG3cX2ObcVIlNtthnPg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@noble/hashes': 1.7.1
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/errors@0.101.1:
     resolution: {integrity: sha512-BPp3/tD3YyxbV/qGujwrUOluyB4abEHOD1GIgvUGKiLy9S3TNjBzIPLYG0ARVcswvYTEh8r7/hoZcRKtpNpcEQ==}
@@ -1474,6 +1582,14 @@ packages:
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
     dependencies:
       '@fuel-ts/versions': 0.101.3
+    dev: false
+
+  /@fuel-ts/errors@0.103.0:
+    resolution: {integrity: sha512-IvWB/Q7rRNYI/GrLuCD4EiGHOi5a+9a7P3AXMZ8gqE2PA5yYKUPQlI87xTvB9f9ZTiX1H/XwdCKprmKp6Nh16g==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/versions': 0.103.0
+    dev: true
 
   /@fuel-ts/hasher@0.101.1(vitest@3.0.9):
     resolution: {integrity: sha512-diLLZbMvwy6ivkZEBDzh6HXkqPzxCVJov29A4A+ILwvKcXHultJ/36bxj3S415cj5DtgVj8KBoqeo1Sw7cg+rg==}
@@ -1495,6 +1611,18 @@ packages:
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/hasher@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-P1EU4iHb7biGSqIldNEgkULcmrY11xdF9fE4Ja3EUZTViI1ekUt2a7r8402CkafLjBpheKzRpsdyL2pqkxJqdw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@noble/hashes': 1.7.1
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/math@0.101.1:
     resolution: {integrity: sha512-F1bGLZN71DmL5h1/znlXgWahL8A28RMur4B2MscTp/sFyqQ9tHlpEDjdF2ajr3lSxlMWohDJbElCNramLqE/Tg==}
@@ -1512,6 +1640,16 @@ packages:
       '@fuel-ts/errors': 0.101.3
       '@types/bn.js': 5.1.6
       bn.js: 5.2.1
+    dev: false
+
+  /@fuel-ts/math@0.103.0:
+    resolution: {integrity: sha512-djUGWHC45GN8xiI4r20eg3hs1pHcZzkNLLFoX3Mg4gcEyPesr0dt+TdvyFGr/tBqoEuS+IBAS2rFB6v1f3Q+Xg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/errors': 0.103.0
+      '@types/bn.js': 5.1.6
+      bn.js: 5.2.1
+    dev: true
 
   /@fuel-ts/merkle@0.101.1(vitest@3.0.9):
     resolution: {integrity: sha512-JJEdTQ2BxWHjX09caf42Ebfc32J0dHx/dv9pXfvpxc3BUgdRE8gM0Wvrqq/cu6S2XD/Y6vQp/qhOq9PXWJUuKg==}
@@ -1531,6 +1669,17 @@ packages:
       '@fuel-ts/math': 0.101.3
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/merkle@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-A80K7SZgOcnl0SuxurR+6bOAbKPM/gOMlcHDqeAU2vsClG2Zp3Apu1+v7PZJvPgi8JRUHDuDWlqpkNQvLRDvdQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/program@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-DZzP8CiqXqhi+jR9m0u+lbCrDtojGX5pv+j2lAyGRdyt80UIkFucDrbVXD0v2Iuni02PIaLDEAoum+y/sqGgrw==}
@@ -1548,6 +1697,25 @@ packages:
     transitivePeerDependencies:
       - encoding
       - vitest
+    dev: false
+
+  /@fuel-ts/program@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-GXvFpNsyg0VpDm8DXmpE+2oYSufprcPHciiwET1NpexlCGIdiPhBRDA3hqq6P+n+ovNNMNWHgwNxu77Yle9lxA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/account': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@fuels/vm-asm': 0.62.0
+      ramda: 0.30.1
+    transitivePeerDependencies:
+      - encoding
+      - vitest
+    dev: true
 
   /@fuel-ts/recipes@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-rzVDeJM69Wth8wXly656g3VCNbFpouHfZQA2vJiEoAZn+YB9m9Z73DfAIDn7WUw3Sy/iBAw884OKoV3zZjV8qw==}
@@ -1564,6 +1732,24 @@ packages:
     transitivePeerDependencies:
       - encoding
       - vitest
+    dev: false
+
+  /@fuel-ts/recipes@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-Ei3BTFQXM5Q+7PLln/ChdGis0oHJghdEjr7C8w/3dOGMcTVXwzQOg8kzNzXoYdDMgRxFBG6oX5Wi2JY+x8ShLg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/abi-typegen': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/account': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/contract': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/program': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+    transitivePeerDependencies:
+      - encoding
+      - vitest
+    dev: true
 
   /@fuel-ts/script@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-Bt5NT9R9S9PNi9xmeq20J27QWgD9H4/csH1zXLVkWqS/hy+HKwojwn1n8Nje0ZgbQIBB52OHGiq/txz2XaIsrg==}
@@ -1579,6 +1765,23 @@ packages:
     transitivePeerDependencies:
       - encoding
       - vitest
+    dev: false
+
+  /@fuel-ts/script@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-JN5fY5pNM/lnZlU6ZDKNExK0N5C/9I3/o8FbmZBh3i1pyNxDaceEbEX8YMu/PkWXlG5mbiDXYFNWRmzlV8rZ6g==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/account': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/program': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+    transitivePeerDependencies:
+      - encoding
+      - vitest
+    dev: true
 
   /@fuel-ts/transactions@0.101.3(vitest@3.0.9):
     resolution: {integrity: sha512-JBQ6BOUFiI/UX1VAvY+8AdS73XCTRirOBF/aLrnc8X+uVpoyHKvDaM+oWzl6YMMkgAGVz+D4DgYkjNWiKN+oag==}
@@ -1592,6 +1795,21 @@ packages:
       '@fuel-ts/utils': 0.101.3(vitest@3.0.9)
     transitivePeerDependencies:
       - vitest
+    dev: false
+
+  /@fuel-ts/transactions@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-oOZ/2Q1r+2823MDsMdD/pU3TwVmOfdaBjbudC+oCT+fidBZMAVRQfF/i4SWDtPfSsRuZRD0qDUA4zicYpxphiA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+    transitivePeerDependencies:
+      - vitest
+    dev: true
 
   /@fuel-ts/utils@0.101.1(vitest@3.0.9):
     resolution: {integrity: sha512-H7j38/quroMccPrjFrnn+Cuui6iPpyH15NKdBT2XVv96rk9XX2DG5aBIGn+nYqPTA8+W+a7sp3U65sgckyZ4Rg==}
@@ -1616,7 +1834,21 @@ packages:
       '@fuel-ts/math': 0.101.3
       '@fuel-ts/versions': 0.101.3
       fflate: 0.8.2
+      vitest: 3.0.9(@types/node@16.18.104)
+    dev: false
+
+  /@fuel-ts/utils@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-vYPb0vySLq0PZ0ytdWQnSeG1KjRBB90Fet114iS23sAd+Q1DZ75SHcgekPHkA0Hn4mTrE0Blch+d9tLnLeLrdw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    peerDependencies:
+      vitest: 3.0.9
+    dependencies:
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/versions': 0.103.0
+      fflate: 0.8.2
       vitest: 3.0.9(@types/node@16.18.126)
+    dev: true
 
   /@fuel-ts/versions@0.101.1:
     resolution: {integrity: sha512-3/tYZBbCaShkzfrVEBulm83f3MJaUpOCK4q3BpAxvbhWHsKS9AxbLhHWQ0RZUXII5OJmGnSpWfy0Bhe7FYo93A==}
@@ -1634,9 +1866,24 @@ packages:
     dependencies:
       chalk: 4.1.2
       cli-table: 0.3.11
+    dev: false
+
+  /@fuel-ts/versions@0.103.0:
+    resolution: {integrity: sha512-+omgQvyrOY3e41CdeFBbYl3wWkAimLIKx4lwT+wWWH+/Hxqx5J6oy102ETlr7r93u25X2a68K+USZlR6v7JXMA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      cli-table: 0.3.11
+    dev: true
 
   /@fuels/vm-asm@0.60.2:
     resolution: {integrity: sha512-wkCu63jTGJWpRZQirTaB8S4/gyoebEJLk3AKfnykt/lgWp1U9iHOcCICVHQP547i+y8jEVKwk18+huINFyYVFQ==}
+    dev: false
+
+  /@fuels/vm-asm@0.62.0:
+    resolution: {integrity: sha512-W2XoFIzHtHmWaTKzGKhDzkuQHCJO3j/wU3x1ngyleucsjCv3nUUqkRoSPhEo6wTGRqwiq6cmoqOk+FEi4vmxww==}
+    dev: true
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.10.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -3445,6 +3692,47 @@ packages:
       - encoding
       - supports-color
       - vitest
+    dev: false
+
+  /fuels@0.103.0(vitest@3.0.9):
+    resolution: {integrity: sha512-jV/EqE1/kibZzC1jqW4BhRyM7/ndX6+3W176crVs+260T48aa9rkNT1+TNqdmXewmjusqJ7La4GR1Cx7h/ZPcw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
+    hasBin: true
+    dependencies:
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/abi-typegen': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/account': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/contract': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/program': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/recipes': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/script': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9)
+      '@fuel-ts/versions': 0.103.0
+      '@fuels/vm-asm': 0.62.0
+      bundle-require: 5.1.0(esbuild@0.25.3)
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      commander: 13.1.0
+      esbuild: 0.25.3
+      glob: 10.4.5
+      handlebars: 4.7.8
+      joycon: 3.1.1
+      lodash.camelcase: 4.3.0
+      portfinder: 1.0.32
+      toml: 3.0.0
+      uglify-js: 3.19.3
+      yup: 1.6.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - vitest
+    dev: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -5605,6 +5893,31 @@ packages:
       - zod
     dev: false
 
+  /vite-node@3.0.9(@types/node@16.18.104):
+    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@16.18.104)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: false
+
   /vite-node@3.0.9(@types/node@16.18.126):
     resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5628,6 +5941,7 @@ packages:
       - terser
       - tsx
       - yaml
+    dev: true
 
   /vite-node@3.0.9(@types/node@22.5.5):
     resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
@@ -5653,6 +5967,57 @@ packages:
       - tsx
       - yaml
     dev: true
+
+  /vite@6.3.5(@types/node@16.18.104):
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 16.18.104
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.48.0
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
 
   /vite@6.3.5(@types/node@16.18.126):
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
@@ -5755,6 +6120,70 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vitest@3.0.9(@types/node@16.18.104):
+    resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.9
+      '@vitest/ui': 3.0.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 16.18.104
+      '@vitest/expect': 3.0.9
+      '@vitest/mocker': 3.0.9(vite@6.3.5)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.0.9
+      '@vitest/snapshot': 3.0.9
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.18
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@16.18.104)
+      vite-node: 3.0.9(@types/node@16.18.104)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: false
+
   /vitest@3.0.9(@types/node@16.18.126):
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5817,6 +6246,7 @@ packages:
       - terser
       - tsx
       - yaml
+    dev: true
 
   /vitest@3.0.9(@types/node@22.5.5):
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}


### PR DESCRIPTION
## Summary

- Bump `fuels` de `0.101.3` para `0.103.0` (dependency + peerDep)
- Bump `fuel-core` no toolchain de `0.43.1` para `0.47.1`
- Corrige erro de gas price estimation que causa falha no submit de transacoes multisig

## Contexto

O node publico Fuel atualizou para fuel-core `0.47.1`, que exige gas price minimo de ~2200. O SDK com fuels `0.101.3` estima ~1570 (regras do fuel-core `0.43.1`), causando rejeicao no submit.

## Breaking changes (0.101.3 → 0.103.0)

- **v0.102.0**: fuel-core schema atualizado para 0.44.0
- **v0.103.0**: Chain ID do devnet atualizado (nao afeta staging/prod)

## Test plan

- [ ] Build do SDK passa sem erros
- [ ] Apos merge, validar release automatica via changesets
- [ ] Atualizar bako-safe-api staging com nova versao
- [ ] Testar tx multisig end-to-end em staging