### PR TITLE
fix: upgrade fuels to 0.103.0 and increase maxFee multiplier to 4x

### DIFF
--- a/packages/sdk/src/modules/vault/Vault.ts
+++ b/packages/sdk/src/modules/vault/Vault.ts
@@ -3,7 +3,6 @@ import {
   arrayify,
   bn,
   BN,
-  calculateGasFee,
   GetAddressTypeResponse,
   hexlify,
   Predicate,
@@ -13,13 +12,11 @@ import {
   transactionRequestify,
   TransactionRequestLike,
   TransactionResponse,
-  TransactionType,
   ZeroBytes32,
 } from 'fuels';
 
 import { VaultConfigurable, VaultTransaction, VaultConfig } from './types';
 import {
-  FAKE_WITNESSES,
   parseConfig,
   assembleTransferToContractScript,
 } from './utils';
@@ -211,77 +208,6 @@ export class Vault extends Predicate<[]> {
    */
   public async maxGasUsed() {
     return this.transactionService['calculateMaxGasUsed']();
-  }
-
-  /**
-   * Prepares a transaction by estimating gas usage, calculating fees, and adjusting transaction parameters.
-   *
-   * @template T - The type of the transaction request, extending the base `TransactionRequest` type.
-   * @param {T} transactionRequest - The transaction request to prepare.
-   * @returns {Promise<T>} The prepared transaction request.
-   */
-  public async prepareTransaction<T extends TransactionRequest>(
-    transactionRequest: T,
-  ): Promise<T> {
-    const originalMaxFee = transactionRequest.maxFee;
-    const predicateGasUsed = await this.maxGasUsed();
-    this.populateTransactionPredicateData(transactionRequest);
-
-    const witnesses = Array.from(transactionRequest.witnesses);
-    const fakeSignatures = Array.from(
-      { length: this.maxSigners },
-      () => FAKE_WITNESSES,
-    );
-    transactionRequest.witnesses.push(...fakeSignatures);
-
-    const { assembledRequest } = await this.provider.assembleTx({
-      request: transactionRequest,
-      feePayerAccount: this,
-    });
-    transactionRequest = assembledRequest;
-
-    let totalGasUsed = bn(0);
-    transactionRequest.inputs.forEach((input) => {
-      if ('predicate' in input && input.predicate) {
-        input.witnessIndex = 0;
-        input.predicateGasUsed = undefined;
-        totalGasUsed = totalGasUsed.add(predicateGasUsed);
-      }
-    });
-
-    const { gasPriceFactor } = await this.provider.getGasConfig();
-    const { maxFee, gasPrice } = await this.provider.estimateTxGasAndFee({
-      transactionRequest,
-    });
-
-    const serializedTxCount = bn(
-      transactionRequest.toTransactionBytes().length,
-    );
-    totalGasUsed = totalGasUsed.add(serializedTxCount.mul(64));
-
-    const predicateSuccessFeeDiff = calculateGasFee({
-      gas: totalGasUsed,
-      priceFactor: gasPriceFactor,
-      gasPrice,
-    });
-
-    let baseMaxFee = maxFee;
-    if (!originalMaxFee.eq(0) && originalMaxFee.cmp(maxFee) === 1) {
-      baseMaxFee = originalMaxFee;
-    }
-
-    const maxFeeWithPredicateGas = baseMaxFee.add(predicateSuccessFeeDiff);
-
-    // multiplier -> 2x for regular transactions and 5x for upgrade transactions
-    const multiplier =
-      transactionRequest.type === TransactionType.Upgrade ? 50 : 14;
-
-    transactionRequest.maxFee = maxFeeWithPredicateGas.mul(multiplier).div(10);
-
-    await this.provider.estimateTxDependencies(transactionRequest);
-    transactionRequest.witnesses = witnesses;
-
-    return transactionRequest;
   }
 
   /**

--- a/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
+++ b/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
@@ -74,7 +74,7 @@ export class VaultTransactionService {
 
     const maxFeeWithPredicateGas = baseMaxFee.add(predicateSuccessFeeDiff);
     const multiplier =
-      transactionRequest.type === TransactionType.Upgrade ? 50 : 25;
+      transactionRequest.type === TransactionType.Upgrade ? 50 : 40;
     transactionRequest.maxFee = maxFeeWithPredicateGas.mul(multiplier).div(10);
 
     if (transactionRequest.type === TransactionType.Upgrade) {


### PR DESCRIPTION
## Summary
- Upgrade fuels SDK from 0.102.0 to 0.103.0 (fuel-core 0.47.1 compatibility)
- Increase maxFee multiplier from 2.5x to 4x to handle gas price spikes
- Remove unused `Vault.prepareTransaction` (dead code with outdated 1.4x multiplier)

## Context
Transactions were failing with "The provided max fee can't cover the transaction cost" due to gas price spikes on mainnet (904 → 2200 in minutes, caused by bot activity). The 2.5x multiplier wasn't sufficient to absorb these spikes. The 4x multiplier provides adequate margin — users only pay actual gas, maxFee is just a ceiling.

## Changes
- `packages/sdk/package.json` — fuels ^0.102.0 → 0.103.0
- `VaultTransactionService.ts` — multiplier 25 → 40 (2.5x → 4x)
- `Vault.ts` — removed unused `prepareTransaction` method and orphaned imports

## Test plan
- [ ] Verify transaction creation succeeds with new fee estimation
- [ ] Confirm transactions send successfully under current gas prices
- [ ] Validate no regressions on transfer, multisig signing flows