### PR TITLE
chore: add changeset for maxFee multiplier bump to 0.6.3

### DIFF
--- a/.changeset/maxfee-multiplier.md
+++ b/.changeset/maxfee-multiplier.md
@@ -1,0 +1,5 @@
+---
+"bakosafe": patch
+---
+
+fix: increase maxFee multiplier from 2.5x to 4x to handle gas price spikes and remove unused Vault.prepareTransaction


### PR DESCRIPTION
## Summary
- Add missing changeset for the maxFee multiplier increase (2.5x → 4x) and dead code removal merged in PR #71
- This will trigger the release of bakosafe 0.6.3

## Context
PR #71 was merged without a changeset covering the multiplier and dead code changes. This PR adds the changeset so Changesets bot can publish 0.6.3.