### PR TITLE
fix: include predicateGasUsed in fee estimation for multisig vaults

### DIFF
--- a/.changeset/fix-maxfee-multisig.md
+++ b/.changeset/fix-maxfee-multisig.md
@@ -1,0 +1,12 @@
+---
+"bakosafe": patch
+---
+
+fix: include predicateGasUsed in fee estimation for multisig vaults
+
+Keep predicateGasUsed on inputs when calling estimateTxGasAndFee so the
+node calculates the full transaction cost including predicate execution,
+vmInitialization, and contractRoot costs. Previously these were zeroed and
+compensated separately, but the separate calculation missed vmInit and
+contractRoot costs, causing maxFee to be insufficient for vaults with
+many signers (3/5, 5/10, etc).

--- a/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
+++ b/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
@@ -1,7 +1,6 @@
 import {
   type BN,
   bn,
-  calculateGasFee,
   ScriptTransactionRequest,
   type TransactionRequest,
   type TransactionRequestLike,
@@ -47,24 +46,20 @@ export class VaultTransactionService {
     })) as AssembleTxResult;
     transactionRequest = assembledRequest;
 
-    let totalGasUsed = bn(0);
+    // Keep predicateGasUsed on inputs so estimateTxGasAndFee calculates
+    // the full cost including predicate execution, vmInitialization, and
+    // contractRoot costs. Previously this was zeroed and compensated
+    // separately, but the separate calculation missed vmInit and contractRoot
+    // costs, causing maxFee to be insufficient for vaults with many signers.
     transactionRequest.inputs.forEach((input) => {
       if ("predicate" in input && input.predicate) {
         input.witnessIndex = 0;
-        input.predicateGasUsed = undefined;
-        totalGasUsed = totalGasUsed.add(predicateGasUsed);
+        input.predicateGasUsed = predicateGasUsed;
       }
     });
 
-    const { gasPriceFactor } = await this.vault.provider.getGasConfig();
-    const { maxFee, gasPrice } = await this.vault.provider.estimateTxGasAndFee({
+    const { maxFee } = await this.vault.provider.estimateTxGasAndFee({
       transactionRequest,
-    });
-
-    const predicateSuccessFeeDiff = calculateGasFee({
-      gas: totalGasUsed,
-      priceFactor: gasPriceFactor,
-      gasPrice,
     });
 
     let baseMaxFee = maxFee;
@@ -72,13 +67,12 @@ export class VaultTransactionService {
       baseMaxFee = originalMaxFee;
     }
 
-    const maxFeeWithPredicateGas = baseMaxFee.add(predicateSuccessFeeDiff);
     const multiplier =
-      transactionRequest.type === TransactionType.Upgrade ? 50 : 40;
-    transactionRequest.maxFee = maxFeeWithPredicateGas.mul(multiplier).div(10);
+      transactionRequest.type === TransactionType.Upgrade ? 50 : 20;
+    transactionRequest.maxFee = baseMaxFee.mul(multiplier).div(10);
 
     if (transactionRequest.type === TransactionType.Upgrade) {
-      transactionRequest.maxFee = maxFeeWithPredicateGas.mul(5);
+      transactionRequest.maxFee = baseMaxFee.mul(5);
     }
 
     await this.vault.provider.estimateTxDependencies(transactionRequest);


### PR DESCRIPTION
## Problem

Vaults with many signers (3/5, 5/10) fail on transaction submission with:
> "The provided max fee can't cover the transaction cost. The minimal gas price should be 2200, while it is 2113"

## Root Cause

`prepareTransaction` zeroed `predicateGasUsed` on inputs before calling `estimateTxGasAndFee`, then compensated with a separate `calculateGasFee` call. This separate calculation missed two per-predicate costs that the node includes:

1. **vmInitializationCost** — gas to initialize VM for predicate execution
2. **contractRoot cost** — gas proportional to predicate bytecode size

For vault 1/1, these costs are small and the 4x multiplier covers them. For vault 3/5+, the bytecode is large, the gap reaches ~3.8x, and the 4x multiplier barely fails.

## Fix

Keep `predicateGasUsed` on inputs so `estimateTxGasAndFee` calculates the full cost (including vmInit + contractRoot + predicate execution) in a single pass. Reduce multiplier from 4x to 2x since the base is now correct and needs less margin.

## Impact

- maxFee reserve increases slightly (~$0.002 more per tx) but the user only pays actual gasUsed
- Vaults with many signers stop failing on submission
- 2x multiplier handles gas price spikes up to 100% (worst observed was 10%)