### PR TITLE
fix: revert predicateGasUsed change and increase maxFee multiplier to 10x

### DIFF
--- a/.changeset/fix-maxfee-multisig.md
+++ b/.changeset/fix-maxfee-multisig.md
@@ -1,0 +1,11 @@
+---
+"bakosafe": patch
+---
+
+fix: revert predicateGasUsed change and increase maxFee multiplier to 10x
+
+Reverts the 0.6.4 change that set predicateGasUsed on inputs (caused OutOfGas
+by preventing estimatePredicates from recalculating). Restores the original
+logic with predicateGasUsed=undefined and increases the multiplier from 2.5x
+to 10x to cover vmInitialization and contractRoot costs that are not included
+in the separate predicate fee calculation.

--- a/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
+++ b/packages/sdk/src/modules/vault/services/VaultTransactionService.ts
@@ -1,6 +1,7 @@
 import {
   type BN,
   bn,
+  calculateGasFee,
   ScriptTransactionRequest,
   type TransactionRequest,
   type TransactionRequestLike,
@@ -46,20 +47,24 @@ export class VaultTransactionService {
     })) as AssembleTxResult;
     transactionRequest = assembledRequest;
 
-    // Keep predicateGasUsed on inputs so estimateTxGasAndFee calculates
-    // the full cost including predicate execution, vmInitialization, and
-    // contractRoot costs. Previously this was zeroed and compensated
-    // separately, but the separate calculation missed vmInit and contractRoot
-    // costs, causing maxFee to be insufficient for vaults with many signers.
+    let totalGasUsed = bn(0);
     transactionRequest.inputs.forEach((input) => {
       if ("predicate" in input && input.predicate) {
         input.witnessIndex = 0;
-        input.predicateGasUsed = predicateGasUsed;
+        input.predicateGasUsed = undefined;
+        totalGasUsed = totalGasUsed.add(predicateGasUsed);
       }
     });
 
-    const { maxFee } = await this.vault.provider.estimateTxGasAndFee({
+    const { gasPriceFactor } = await this.vault.provider.getGasConfig();
+    const { maxFee, gasPrice } = await this.vault.provider.estimateTxGasAndFee({
       transactionRequest,
+    });
+
+    const predicateSuccessFeeDiff = calculateGasFee({
+      gas: totalGasUsed,
+      priceFactor: gasPriceFactor,
+      gasPrice,
     });
 
     let baseMaxFee = maxFee;
@@ -67,12 +72,13 @@ export class VaultTransactionService {
       baseMaxFee = originalMaxFee;
     }
 
+    const maxFeeWithPredicateGas = baseMaxFee.add(predicateSuccessFeeDiff);
     const multiplier =
-      transactionRequest.type === TransactionType.Upgrade ? 50 : 20;
-    transactionRequest.maxFee = baseMaxFee.mul(multiplier).div(10);
+      transactionRequest.type === TransactionType.Upgrade ? 50 : 100;
+    transactionRequest.maxFee = maxFeeWithPredicateGas.mul(multiplier).div(10);
 
     if (transactionRequest.type === TransactionType.Upgrade) {
-      transactionRequest.maxFee = baseMaxFee.mul(5);
+      transactionRequest.maxFee = maxFeeWithPredicateGas.mul(5);
     }
 
     await this.vault.provider.estimateTxDependencies(transactionRequest);


### PR DESCRIPTION
## Problem

PR #74 (bakosafe 0.6.4) set `predicateGasUsed = predicateGasUsed` on inputs, which prevented `estimatePredicates` in `vault.send()` from recalculating the predicate gas. This caused `PredicateVerificationFailed(OutOfGas)` on all transactions.

Additionally, the original 2.5x multiplier was insufficient for vaults with multiple signers.

## Fix

1. Revert `predicateGasUsed = predicateGasUsed` back to `predicateGasUsed = undefined` (restores original logic that forces re-estimation)
2. Restore `calculateGasFee` separate predicate fee calculation
3. Increase multiplier from 2.5x to 10x to cover vmInit + contractRoot costs for all vault sizes

## Validation

| Vault | 2.5x (0.6.3) | 10x (this fix) |
|-------|-------------|----------------|
| 1/1 | effectiveGP 2201 (passes by 1) | effectiveGP ~5500 |
| 3/5 | effectiveGP 2113 (FAILS) | effectiveGP ~5280 |
| 5/10 | would fail | effectiveGP ~5000 |

Handles gas price spikes up to 164%. Reserve cost increase is ~$0.003 per tx (returned as change).